### PR TITLE
Fix a ClassCastException

### DIFF
--- a/preference/src/main/kotlin/PreferencesEditor.kt
+++ b/preference/src/main/kotlin/PreferencesEditor.kt
@@ -16,7 +16,13 @@ public fun preferencesEditor (context: Context, vararg pairs: Pair<String, Any>)
     for ((key, value) in pairs) {
         when (value) {
             is String -> editor.putString(key, value)
-            is Set<*> -> editor.putStringSet(key, value as HashSet<String>)
+            is Set<*> -> {
+                if (!value.all { it is String }) {
+                    throw IllegalArgumentException("Only Set<String> is supported")
+                }
+                [suppress("UNCHECKED_CAST")]
+                editor.putStringSet(key, value as Set<String>)
+            }
             is Int -> editor.putInt(key, value)
             is Long -> editor.putLong(key, value)
             is Float -> editor.putFloat(key, value)


### PR DESCRIPTION
There're two cases when `ClassCastException` may occur.
1. When something that is a `Set<*>`, but not `HashSet<*>` is passed.
2. When a set like `setOf("ABC", 123)` is stored, and then is read as a `Set<String>`. It is more dangerous than the previous one because you receive an Exception on value read, not on write.
